### PR TITLE
Synchronize viewer and thumbnail selection, close app on main window close

### DIFF
--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -71,6 +71,9 @@ namespace Illustra
         {
             base.OnInitialized();
 
+            // メインウィンドウが閉じられたらアプリ終了
+            Application.Current.ShutdownMode = ShutdownMode.OnMainWindowClose;
+
             // キーボードショートカットハンドラーを初期化
             KeyboardShortcutHandler.Instance.ReloadShortcuts();
         }

--- a/src/Views/ImageViewerWindow.xaml.cs
+++ b/src/Views/ImageViewerWindow.xaml.cs
@@ -12,11 +12,13 @@ using Illustra.Helpers.Interfaces;
 using Illustra.Functions;
 using MahApps.Metro.Controls;
 using System.Windows.Controls.Primitives;
+using System.IO;
 
 namespace Illustra.Views
 {
     public partial class ImageViewerWindow : MetroWindow, INotifyPropertyChanged
     {
+        private const string CONTROL_ID = "ImageViewer";
         // フルスクリーン切り替え前のウィンドウ状態を保存
         private WindowState _previousWindowState;
         private WindowStyle _previousWindowStyle;
@@ -86,8 +88,19 @@ namespace Illustra.Views
             }
         }
 
-        public string FileName { get; private set; }
-        public BitmapSource? ImageSource { get; private set; }
+        private BitmapSource? _imageSource = null;
+        public BitmapSource? ImageSource
+        {
+            get => _imageSource;
+            private set
+            {
+                if (_imageSource != value)
+                {
+                    _imageSource = value;
+                    OnPropertyChanged(nameof(ImageSource));
+                }
+            }
+        }
 
         public event PropertyChangedEventHandler? PropertyChanged;
         protected virtual void OnPropertyChanged(string propertyName)
@@ -98,11 +111,9 @@ namespace Illustra.Views
         private DispatcherTimer hideCursorTimer;
         private readonly IImageCache _imageCache;
 
-        public ImageViewerWindow(string filePath)
+        public ImageViewerWindow()
         {
             InitializeComponent();
-            FileName = System.IO.Path.GetFileName(filePath);
-            _currentFilePath = filePath;
             DataContext = this;
 
             // キャッシュの初期化
@@ -123,6 +134,10 @@ namespace Illustra.Views
             // イベントの購読
             var eventAggregator = ContainerLocator.Container.Resolve<IEventAggregator>();
             eventAggregator?.GetEvent<RatingChangedEvent>()?.Subscribe(OnRatingChanged);
+            eventAggregator?.GetEvent<FileSelectedEvent>()?.Subscribe(OnFileSelected,
+                ThreadOption.UIThread,
+                false,
+                filter => filter.SourceId != CONTROL_ID); // 自分が発信したイベントは無視
 
             this.StateChanged += MainWindow_StateChanged;
 
@@ -136,9 +151,6 @@ namespace Illustra.Views
 
             // ウィンドウの状態を復元
             var settings = ViewerSettingsHelper.LoadSettings();
-
-            // フルスクリーン設定を保存して、Loaded後に適用
-            IsFullScreen = settings.IsFullScreen; // プロパティ経由で設定
 
             // プロパティパネルの表示状態を設定
             PropertyPanel.Visibility = settings.VisiblePropertyPanel ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
@@ -163,96 +175,36 @@ namespace Illustra.Views
 
             // ウィンドウが表示された後に実行する処理
             Loaded += (s, e) => OnWindowLoaded();
-        }
-
-
-
-        private async Task LoadImagePropertiesAsync(string filePath)
-        {
-            try
-            {
-                // ファイルからプロパティを読み込む
-                var newProperties = await ImagePropertiesModel.LoadFromFileAsync(filePath);
-
-                // データベースからレーティングを読み込んで設定
-                var fileNode = await _dbManager.GetFileNodeAsync(filePath);
-                if (fileNode != null)
-                {
-                    newProperties.Rating = fileNode.Rating;
-                }
-
-                // プロパティの更新はUIスレッドで行う
-                await Application.Current.Dispatcher.InvokeAsync(() =>
-                {
-                    // まず新しいプロパティインスタンスをセット（これによりPropertyChangedイベントハンドラが設定される）
-                    Properties = newProperties;
-                    _currentFilePath = filePath;
-                    FileName = System.IO.Path.GetFileName(filePath);
-
-                    // PropertyPanelControlにプロパティを設定
-                    if (PropertyPanelControl != null)
-                    {
-                        PropertyPanelControl.ImageProperties = Properties;
-                        PropertyPanelControl.DataContext = Properties;
-                    }
-
-                    OnPropertyChanged(nameof(ImageSource));
-                    OnPropertyChanged(nameof(FileName));
-                    OnPropertyChanged(nameof(Properties));
-                });
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"Error loading image properties: {ex.Message}");
-                MessageBox.Show($"画像プロパティの読み込みに失敗しました：{ex.Message}", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
-            }
+            Unloaded += OnWindowUnloaded();
         }
 
         private async void OnWindowLoaded()
         {
-            // キャッシュから画像を読み込み（なければ新規作成）
-            LoadAndDisplayImage(_currentFilePath);
+            // 画像の読み込みとキャッシュはSwitchToImageに委譲
+            await SwitchToImage(_currentFilePath, true);
 
-            // プロパティの読み込み
-            await LoadImagePropertiesAsync(_currentFilePath);
-
-            // プロパティパネルにプロパティを設定
-            PropertyPanelControl.OnFileSelected(new SelectedFileModel("", _currentFilePath, Properties.Rating));
-            /*
-                        // フルスクリーン状態を設定
-                        if (_isFullScreen)
-                        {
-                            this.ShowTitleBar = false; // フルスクリーン時はタイトルバーを非表示
-                            _previousWindowState = WindowState;
-                            _previousWindowStyle = WindowStyle;
-
-                            // フルスクリーン状態にする
-                            WindowStyle = WindowStyle.None;
-                            WindowState = WindowState.Maximized;
-
-                            // 確実に設定が有効になるように少し待つ
-                            await Task.Delay(50);
-                        }
-            */
-            // フォーカスを確実に設定
+            // ウィンドウ固有の初期化処理のみ残す
             await Dispatcher.BeginInvoke(DispatcherPriority.Render, new Action(() =>
             {
-                Activate(); // ウィンドウをアクティブにする
-                Focus();    // ウィンドウにフォーカスを設定
-                MainImage.Focus(); // 画像にフォーカス
+                Activate();
+                Focus();
+                MainImage.Focus();
             }));
 
-            // 前後の画像をキャッシュ
-            var viewModel = Parent?.GetViewModel();
-            if (viewModel != null)
+            // ウィンドウの状態設定
+            MainWindow_StateChanged(null, null);
+        }
+
+
+        private RoutedEventHandler OnWindowUnloaded()
+        {
+            return (s, e) =>
             {
-                var files = viewModel.FilteredItems.Cast<FileNodeModel>().ToList();
-                var currentIndex = files.FindIndex(f => f.FullPath == _currentFilePath);
-                if (currentIndex >= 0)
-                {
-                    _imageCache.UpdateCache(files, currentIndex);
-                }
-            }
+                // イベントの購読解除
+                var eventAggregator = ContainerLocator.Container.Resolve<IEventAggregator>();
+                eventAggregator?.GetEvent<RatingChangedEvent>()?.Unsubscribe(OnRatingChanged);
+                eventAggregator?.GetEvent<FileSelectedEvent>()?.Unsubscribe(OnFileSelected);
+            };
         }
 
         private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
@@ -499,7 +451,7 @@ namespace Illustra.Views
             string? previousFilePath = Parent.GetPreviousImage(_currentFilePath);
             if (!string.IsNullOrEmpty(previousFilePath))
             {
-                _ = SwitchToImage(previousFilePath);
+                _ = SwitchToImage(previousFilePath, true);
             }
         }
 
@@ -512,7 +464,7 @@ namespace Illustra.Views
             string? nextFilePath = Parent.GetNextImage(_currentFilePath);
             if (!string.IsNullOrEmpty(nextFilePath))
             {
-                _ = SwitchToImage(nextFilePath);
+                _ = SwitchToImage(nextFilePath, true);
             }
             else if (_isSlideshowActive)
             {
@@ -557,18 +509,23 @@ namespace Illustra.Views
         }
 
         // 新しい画像を読み込む
-        private async Task SwitchToImage(string filePath)
+        private async Task SwitchToImage(string filePath, bool notifyFileSelection)
         {
             try
             {
+                if (_currentFilePath?.Equals(filePath, StringComparison.OrdinalIgnoreCase) ?? false)
+                {
+                    // 同じ画像の場合は何もしない
+                    return;
+                }
+
                 // 1. 現在のファイルパスを更新
                 _currentFilePath = filePath;
 
                 // 2. まず現在の画像を表示（キャッシュミス時は自動で読み込まれる）
                 LoadAndDisplayImage(filePath);
 
-                // 3. 画像のプロパティを読み込み
-                await LoadImagePropertiesAsync(filePath);
+                // 3. 画像のプロパティは FileSelectedEvent で更新される
 
                 // 4. 前後の画像をキャッシュ
                 var viewModel = Parent?.GetViewModel();
@@ -605,7 +562,12 @@ namespace Illustra.Views
                 }
 
                 // 親ウィンドウのサムネイル選択を更新
-                Parent?.SyncThumbnailSelection(filePath);
+                if (notifyFileSelection)
+                {
+                    var eventAggregator = ContainerLocator.Container.Resolve<IEventAggregator>();
+                    eventAggregator?.GetEvent<FileSelectedEvent>()?.Publish(
+                        new SelectedFileModel(CONTROL_ID, filePath, Properties.Rating));
+                }
             }
             catch (Exception ex)
             {
@@ -749,9 +711,9 @@ namespace Illustra.Views
                 // キャッシュをクリア
                 _imageCache.Clear();
 
-                // 明示的なGCを実行
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
+                var eventAggregator = ContainerLocator.Container.Resolve<IEventAggregator>();
+                eventAggregator?.GetEvent<RatingChangedEvent>()?.Unsubscribe(OnRatingChanged);
+                eventAggregator?.GetEvent<FileSelectedEvent>()?.Unsubscribe(OnFileSelected);
             }
             catch (Exception ex)
             {
@@ -898,7 +860,7 @@ namespace Illustra.Views
                 // 次の画像があれば表示、なければビューアを閉じる
                 if (!string.IsNullOrEmpty(nextFilePath))
                 {
-                    _ = SwitchToImage(nextFilePath);
+                    _ = SwitchToImage(nextFilePath, true);
                 }
                 else
                 {
@@ -926,7 +888,7 @@ namespace Illustra.Views
                 if (files.Any())
                 {
                     // 先頭の画像に切り替え
-                    _ = SwitchToImage(files.First().FullPath);
+                    _ = SwitchToImage(files.First().FullPath, true);
                 }
             }
         }
@@ -943,9 +905,35 @@ namespace Illustra.Views
                 if (files.Any())
                 {
                     // 末尾の画像に切り替え
-                    _ = SwitchToImage(files.Last().FullPath);
+                    _ = SwitchToImage(files.Last().FullPath, true);
                 }
             }
+        }
+
+        /// <summary>
+        /// 指定されたパスの画像をロードします
+        /// </summary>
+        /// <param name="filePath">画像ファイルのパス</param>
+        public void LoadImageFromPath(string filePath, bool notifyFileSelection = true)
+        {
+            if (string.IsNullOrEmpty(filePath))
+                return;
+
+            if (!File.Exists(filePath))
+                return;
+
+            if (_currentFilePath?.Equals(filePath, StringComparison.OrdinalIgnoreCase) ?? false)
+            {
+                // 同じ画像の場合は何もしない
+                return;
+            }
+
+            _ = SwitchToImage(filePath, notifyFileSelection);
+        }
+
+        private void OnFileSelected(SelectedFileModel args)
+        {
+            LoadImageFromPath(args.FullPath, notifyFileSelection: false);
         }
 
         private void OnRatingChanged(RatingChangedEventArgs args)

--- a/src/Views/PropertyPanelControl.xaml.cs
+++ b/src/Views/PropertyPanelControl.xaml.cs
@@ -102,15 +102,9 @@ namespace Illustra.Views
             _db = ContainerLocator.Container.Resolve<DatabaseManager>();
 
             Loaded += PropertyPanelControl_Loaded;
+            Unloaded += PropertyPanelControl_Unloaded;
             PreviewMouseDoubleClick += PropertyPanelControl_PreviewMouseDoubleClick;
             IsVisibleChanged += PropertyPanelControl_IsVisibleChanged;
-        }
-
-        private void PropertyPanelControl_PreviewMouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
-        {
-            // プロパティパネル上でのダブルクリックイベントを処理済みとしてマークし、
-            // 親コントロールへの伝播を停止
-            e.Handled = true;
         }
 
         private void PropertyPanelControl_Loaded(object sender, RoutedEventArgs e)
@@ -121,7 +115,24 @@ namespace Illustra.Views
             _eventAggregator.GetEvent<RatingChangedEvent>().Subscribe(OnRatingChanged);
             _eventAggregator.GetEvent<FilterChangedEvent>().Subscribe(OnFilterChanged, ThreadOption.UIThread, false,
                 filter => filter.SourceId != CONTROL_ID); // 自分が発信したイベントは無視);
+        }
 
+        private void PropertyPanelControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            if (_eventAggregator != null)
+            {
+                _eventAggregator.GetEvent<FileSelectedEvent>().Unsubscribe(OnFileSelected);
+                _eventAggregator.GetEvent<FolderSelectedEvent>().Unsubscribe(OnFolderChanged);
+                _eventAggregator.GetEvent<RatingChangedEvent>().Unsubscribe(OnRatingChanged);
+                _eventAggregator.GetEvent<FilterChangedEvent>().Unsubscribe(OnFilterChanged);
+            }
+        }
+
+        private void PropertyPanelControl_PreviewMouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            // プロパティパネル上でのダブルクリックイベントを処理済みとしてマークし、
+            // 親コントロールへの伝播を停止
+            e.Handled = true;
         }
 
 

--- a/src/Views/ThumbnailListControl.xaml.cs
+++ b/src/Views/ThumbnailListControl.xaml.cs
@@ -32,7 +32,7 @@ namespace Illustra.Views
         private IEventAggregator _eventAggregator = null!;
         private MainViewModel _viewModel;
         // 画像閲覧用
-        private ImageViewerWindow? _currentViewerWindow;
+        private ImageViewerWindow? _imageViewerWindow;
         private string? _currentFolderPath;
 
         private AppSettingsModel _appSettings;
@@ -254,6 +254,14 @@ namespace Illustra.Views
             _scrollStopTimer.Tick += ScrollStopTimer_Tick;
         }
 
+        private void OnFileSelected(SelectedFileModel args)
+        {
+            if (args.SourceId != CONTROL_ID)
+            {
+                SelectThumbnail(args.FullPath);
+            }
+        }
+
         private void ThumbnailListControl_Loaded(object sender, RoutedEventArgs e)
         {
             // ContainerLocatorを使ってEventAggregatorを取得
@@ -269,6 +277,8 @@ namespace Illustra.Views
             _eventAggregator.GetEvent<RatingChangedEvent>().Subscribe(OnRatingChanged, ThreadOption.UIThread, false);
             _eventAggregator.GetEvent<LanguageChangedEvent>().Subscribe(OnLanguageChanged);
             _eventAggregator.GetEvent<SortOrderChangedEvent>().Subscribe(OnSortOrderChanged, ThreadOption.UIThread);
+            _eventAggregator.GetEvent<FileSelectedEvent>().Subscribe(OnFileSelected, ThreadOption.UIThread, false,
+                filter => filter.SourceId != CONTROL_ID); // 自分が発信したイベントは無視
 
             // ItemContainerGenerator.StatusChangedイベントを登録
             ThumbnailItemsControl.ItemContainerGenerator.StatusChanged += ThumbnailItemsControl_StatusChanged;
@@ -457,36 +467,6 @@ namespace Illustra.Views
             }
         }
 
-        /// <summary>
-        /// サムネイル一覧の選択を指定されたファイルパスに同期します
-        /// </summary>
-        /// <param name="filePath">選択するファイルパス</param>
-        public void SyncThumbnailSelection(string filePath)
-        {
-            if (string.IsNullOrEmpty(filePath))
-                return;
-
-            // サムネイルの選択と表示を更新
-            SelectThumbnail(filePath);
-
-            // UIスレッドで実行することを確保
-            Dispatcher.InvokeAsync(async () =>
-            {
-                // 選択したアイテムをビューに表示
-                if (_viewModel.SelectedItems.Any())
-                {
-                    var selectedItem = _viewModel.SelectedItems.First();
-                    ThumbnailItemsControl.ScrollIntoView(selectedItem);
-
-                    // レイアウトの更新を待機
-                    await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Render);
-
-                    // コンテナを取得して画面内に表示
-                    var container = ThumbnailItemsControl.ItemContainerGenerator.ContainerFromItem(selectedItem) as ListViewItem;
-                    container?.BringIntoView();
-                }
-            }, DispatcherPriority.Render);
-        }
         private async void ThumbnailItemsControl_Loaded(object sender, RoutedEventArgs e)
         {
             var scrollViewer = await Task.Run(() => UIHelper.FindVisualChild<ScrollViewer>(ThumbnailItemsControl));
@@ -1993,37 +1973,40 @@ namespace Illustra.Views
         {
             try
             {
-                var viewer = new ImageViewerWindow(filePath)
+                // 表示中のウィンドウがない場合は新しく作成
+                if (_imageViewerWindow == null)
                 {
-                    Parent = this
-                };
-                _currentViewerWindow = viewer; // 現在開いているビューアを追跡
-
-                // 初期状態のフルスクリーンモードを設定
-                _thumbnailLoader.SetFullscreenMode(viewer.IsFullScreen);
-
-                // ビューワが全画面表示モードを開始/終了した時のイベントを設定
-                viewer.IsFullscreenChanged += (s, e) =>
-                {
-                    _thumbnailLoader.SetFullscreenMode(viewer.IsFullScreen);
-                };
-
-                // ビューワが閉じられた時のイベントを設定
-                viewer.Closed += (s, e) =>
-                {
-                    _thumbnailLoader.SetFullscreenMode(false);
-                    _currentViewerWindow = null;
-
-                    // サムネイルの再生成
-                    var scrollViewer = UIHelper.FindVisualChild<ScrollViewer>(ThumbnailItemsControl);
-                    if (scrollViewer != null)
+                    _imageViewerWindow = new ImageViewerWindow()
                     {
-                        _ = LoadVisibleThumbnailsAsync(scrollViewer);
-                    }
-                };
+                        Parent = this
+                    };
 
-                viewer.Show();
-                viewer.Focus(); // ビューアウィンドウにフォーカスを設定
+                    // イベントハンドラを設定
+                    _imageViewerWindow.IsFullscreenChanged += (s, e) =>
+                    {
+                        _thumbnailLoader?.SetFullscreenMode(_imageViewerWindow?.IsFullScreen ?? false);
+                    };
+
+                    _imageViewerWindow.Closed += (s, e) =>
+                    {
+                        _thumbnailLoader?.SetFullscreenMode(false);
+
+                        // サムネイルの再生成
+                        var scrollViewer = UIHelper.FindVisualChild<ScrollViewer>(ThumbnailItemsControl);
+                        if (scrollViewer != null)
+                        {
+                            _ = LoadVisibleThumbnailsAsync(scrollViewer);
+                        }
+
+                        // インスタンスをクリア
+                        _imageViewerWindow = null;
+                    };
+                }
+
+                // 画像を読み込んでウィンドウを表示
+                _imageViewerWindow.LoadImageFromPath(filePath);
+                _imageViewerWindow.Show();
+                _imageViewerWindow.Focus(); // ビューアウィンドウにフォーカスを設定
             }
             catch (Exception ex)
             {
@@ -2034,6 +2017,9 @@ namespace Illustra.Views
                     (string)Application.Current.FindResource("String_Thumbnail_FileOperationErrorTitle"),
                     MessageBoxButton.OK,
                     MessageBoxImage.Error);
+
+                // エラー時はインスタンスをクリア
+                _imageViewerWindow = null;
             }
         }
 


### PR DESCRIPTION
Implement synchronization between the viewer and the thumbnail selection. Modify the application to exit when the main window is closed. Additionally, manage event subscriptions and improve the handling of the image viewer window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The application now exits completely when the main window is closed.
	- The image viewer has been refined for smoother image loading and more reliable file selection.
- **Bug Fixes**
	- Thumbnail management has been improved to ensure only one viewer instance is active.
	- Enhancements in control panel interactions offer a more stable and responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->